### PR TITLE
improved hire-logic ( hopefully :)

### DIFF
--- a/AutocratV3.js
+++ b/AutocratV3.js
@@ -1,7 +1,7 @@
 "use strict";
 // The Idle Class Autocrat
 // made with luv by argembarger
-// v3.2.0, last tested with The Idle Class v0.6.0
+// v3.2.1, last tested with The Idle Class v0.8.2
 // USE AT OWN RISK -- feel free to steal
 // not responsible if your game gets hurt >_>
 // Export Early / Export Often
@@ -30,7 +30,6 @@ class IdleClassAutocrat {
 		this.autocratManageLoopMillis = 2500; // Default 2500, runs an Autocrat update every 2.5 seconds
 		this.autocratInnerLoopMillis = 100; // Default 100, does individual Autocrat actions every 0.1 seconds
 		this.upgradeSpendFraction = 1.0; // Default 1.0, willing to spend 100% on upgrades, RATIO VALUE, 0.67 = 67%
-		this.employeeSpendFraction = 0.999; // Default 0.999, willing to spend 99.9% on employees, RATIO VALUE, 0.67 = 67%
 		this.maxAllowableRisk = 0.0; // Default 0.0%, stops R&D hiring above this risk value, PERCENTAGE VALUE, 67.0 = 67%
 		this.acquisitionStopHiringFraction = 0.666; // Default 0.666, stops hiring acq employees at less than 66.6% workers remaining, RATIO VALUE, 0.67 = 67%
 		this.bankruptcyResetFraction = 0.1; // Default 0.1, makes every bankruptcy 110%, RATIO VALUE, 0.67 = 67%
@@ -106,13 +105,14 @@ class IdleClassAutocrat {
 			}
 		};
 		this.autoHR = function() {
-			// Based on currently-selected Purchase Rate.
-			// Try to buy first employee of each type right away, though.
+			// Based on current share of total income
 			for(let i = 0; i <= 11; i++) {
 				this.currEmployee = game.units.peek(0)[i];
+				let fairShare = parseFloat(this.currEmployee.shareOfTotal()) / 100;
+				// ( if possible ) always buy til first 5 | to activate next higher unit
 				if(this.currEmployee.num.val() <= 4 && (this.currEmployee.price.val() <= game.currentCash.val())) {
 					this.currEmployee.buy();
-				} else if(this.currEmployee.price.val() < (game.currentCash.val() * this.employeeSpendFraction)) {
+				} else if(this.currEmployee.price.val() < (game.currentCash.val() * fairShare)) {
 					this.currEmployee.buy();
 				}
 			}

--- a/AutocratV3.js
+++ b/AutocratV3.js
@@ -1,7 +1,7 @@
 "use strict";
 // The Idle Class Autocrat
 // made with luv by argembarger
-// v3.2.1, last tested with The Idle Class v0.8.2
+// v3.2.2, last tested with The Idle Class v0.8.2
 // USE AT OWN RISK -- feel free to steal
 // not responsible if your game gets hurt >_>
 // Export Early / Export Often
@@ -105,9 +105,12 @@ class IdleClassAutocrat {
 			}
 		};
 		this.autoHR = function() {
-			// Based on current share of total income
-			for(let i = 0; i <= 11; i++) {
-				this.currEmployee = game.units.peek(0)[i];
+			// reverse the loop | in favour of more "productive" units
+			for(let i = 11; i >= 0; i--) {
+				this.currEmployee = game.units.peek()[i];
+				// No cheating, Sir (:
+				if(!this.currEmployee.available()) continue;
+				// Based on current share of total income
 				let fairShare = parseFloat(this.currEmployee.shareOfTotal()) / 100;
 				// ( if possible ) always buy til first 5 | to activate next higher unit
 				if(this.currEmployee.num.val() <= 4 && (this.currEmployee.price.val() <= game.currentCash.val())) {


### PR DESCRIPTION
# step 1
**introduced share-of-total, in favour of the fraction-variable.**
what it does is basically, if the total number of one unit is responsible for 49% of your income, we are totally fine, to spent that same amount of money on new ones, right!? ( this dynamically changes over the game course, thankfully. )

# step 2
i reversed the unit-loop, so that we always look on high-profit-units first. ( sound also grateful, right ^^ )
_i also had to introduce a little cheat-prevention on that route._

# motivation
as i saw a new empire rising, i realized that we throw a sht-load of money always on "cheap"-units first \#made-me-cry-inside

> runs like a charm for over an hour now ( as always: in firefox @ linux )
-----
_i also allowed myself to increase the last digit of the autocrat-version by 2 this time around._