### PR TITLE
swapped acquisitoin and bankruptcy | in favour of faster game pace

### DIFF
--- a/AutocratV3.js
+++ b/AutocratV3.js
@@ -1,7 +1,7 @@
 "use strict";
 // The Idle Class Autocrat
 // made with luv by argembarger
-// v3.2.0, last tested with The Idle Class v0.6.0
+// v3.3.0, last tested with The Idle Class v0.8.2
 // USE AT OWN RISK -- feel free to steal
 // not responsible if your game gets hurt >_>
 // Export Early / Export Often
@@ -278,6 +278,13 @@ class IdleClassAutocrat {
 				}
 			}
 		};
+		this.autoBankruptcy = function() {
+			// i suggest always check out from the first game as soon as possible | as this unlocks goals ( wich further increases the multiplier )
+			if( game.bankruptcies.val() === 0 || game.nextBankruptcyBonus.val() > game.stats[this.currentBankruptcyStatsIndex].val() * this.bankruptcyResetFraction ) {
+				this.currProcess = 0;
+				game.restartGame();
+			}
+		};
 		this.autoMicromanage = function() {
 			for (let i = game.activeAcquisitions().length - 1; i >= 0; i--) {
 				this.currAcq = game.activeAcquisitions()[i];
@@ -344,15 +351,6 @@ class IdleClassAutocrat {
 			this.autoMail();
 			this.autoScience();
 		};
-		this.autoUntilAcquisitions = function() {
-			this.autoEarnDollars();
-			this.autoUpgrade();
-			this.autoHR();
-			this.autoMail();
-			this.autoScience();
-			this.autoInvest();
-			this.autoDivest();
-		};
 		this.autoUntilBankruptcy = function() {
 			this.autoEarnDollars();
 			this.autoUpgrade();
@@ -361,6 +359,26 @@ class IdleClassAutocrat {
 			this.autoScience();
 			this.autoInvest();
 			this.autoDivest();
+		};
+		this.autoUntilAcquisitions = function() {
+			this.autoEarnDollars();
+			this.autoUpgrade();
+			this.autoHR();
+			this.autoMail();
+			this.autoScience();
+			this.autoInvest();
+			this.autoDivest();
+			this.autoBankruptcy();
+		};
+		this.autoUntilInfinity = function() {
+			this.autoEarnDollars();
+			this.autoUpgrade();
+			this.autoHR();
+			this.autoMail();
+			this.autoScience();
+			this.autoInvest();
+			this.autoDivest();
+			this.autoBankruptcy();
 			this.autoMicromanage();
 		};
 		// Function to manage state of autocratInnerLoopMillis inner loop
@@ -384,25 +402,26 @@ class IdleClassAutocrat {
 					clearInterval(this.currProcessHandle);
 					this.currProcessHandle = setInterval(this.autoUntilInvestments.bind(this), this.autocratInnerLoopMillis);
 					break;
-				case 3: // Wait for Investments before changing loop to pre-Acquisitions loop.
+				case 3: // Wait for Investments before changing loop to pre-Bankruptcy loop.
 					if(game.locked().investments === true) { break; }
 					this.currProcess = 4;
 					clearInterval(this.currProcessHandle);
-					this.currProcessHandle = setInterval(this.autoUntilAcquisitions.bind(this), this.autocratInnerLoopMillis);
-					break;
-				case 4: // Wait for Acquisitions before changing loop to pre-Bankruptcy loop
-					if(game.locked().acquisitions === true) { break; }
-					this.currProcess = 5;
-					clearInterval(this.currProcessHandle);
 					this.currProcessHandle = setInterval(this.autoUntilBankruptcy.bind(this), this.autocratInnerLoopMillis);
 					break;
-				case 5: // Wait until bankruptcy, then wait for conditions, before declaring bankruptcy and restarting loop.
-					if(game.locked().mail === true) { this.currProcess = 0; break; }
+				case 4: // Wait for Bankruptcy before changing loop to pre-Acquisitions loop
 					if(game.locked().bankruptcy === true) { break; }
-					if(game.nextBankruptcyBonus.val() > game.stats[this.currentBankruptcyStatsIndex].val() * this.bankruptcyResetFraction) {
-						this.currProcess = 0;
-						game.restartGame();
-					}
+					this.currProcess = 5;
+					clearInterval(this.currProcessHandle);
+					this.currProcessHandle = setInterval(this.autoUntilAcquisitions.bind(this), this.autocratInnerLoopMillis);
+					break;
+				case 5: // Wait for Acquisitions before changing loop to pre-Infinity loop
+					if(game.locked().acquisitions === true) { break; }
+					this.currProcess = 6;
+					clearInterval(this.currProcessHandle);
+					this.currProcessHandle = setInterval(this.autoUntilInfinity.bind(this), this.autocratInnerLoopMillis);
+					break;
+					break;
+				case 6: // just fckn run forevor | until the somewhat parallel condition-check sayz something else -- or we define some nu shit to handle ( like elections )
 					break;
 				default:
 					this.currProcess = 0;


### PR DESCRIPTION
_it appears that bankruptcy is unlocked long before acquisition ( especially in the first few businesses ). to my "knowledge" we speed up things by restarting the first few games as early as possible. ( as it is quite a lot of code juggle, i say we raise the second version digit. )_
> as always: does his thing charmingly | in firefox @ linux 