### PR TITLE
it might be most secure to restart both intervals on game-restart ( bankruptcy )

### DIFF
--- a/AutocratV3.js
+++ b/AutocratV3.js
@@ -369,7 +369,7 @@ class IdleClassAutocrat {
 			switch(this.currProcess) {
 				case 0: // Not running; new Autocrat state. Clear any existing loop and start pre-email loop.
 					this.currProcess = 1;
-					if(this.currProcessHandle !== 0) { clearInterval(this.currProcessHandle); }
+					clearInterval(this.currProcessHandle);
 					this.currProcessHandle = setInterval(this.autoUntilEmails.bind(this), this.autocratInnerLoopMillis);
 					break;
 				case 1: // Wait for emails before changing loop to pre-R&D loop.

--- a/AutocratV3.js
+++ b/AutocratV3.js
@@ -403,6 +403,7 @@ class IdleClassAutocrat {
 						this.currProcess = 0;
 						clearInterval(this.currProcessHandle);
 						game.restartGame();
+						this.autoAutoAutocrat(); // super-safely clear the outer-loop too, for fresh businessesss (:
 					}
 					break;
 				default:

--- a/AutocratV3.js
+++ b/AutocratV3.js
@@ -401,6 +401,7 @@ class IdleClassAutocrat {
 					if(game.locked().bankruptcy === true) { break; }
 					if(game.nextBankruptcyBonus.val() > game.stats[this.currentBankruptcyStatsIndex].val() * this.bankruptcyResetFraction) {
 						this.currProcess = 0;
+						clearInterval(this.currProcessHandle);
 						game.restartGame();
 					}
 					break;

--- a/AutocratV3.js
+++ b/AutocratV3.js
@@ -400,10 +400,13 @@ class IdleClassAutocrat {
 					if(game.locked().mail === true) { this.currProcess = 0; break; }
 					if(game.locked().bankruptcy === true) { break; }
 					if(game.nextBankruptcyBonus.val() > game.stats[this.currentBankruptcyStatsIndex].val() * this.bankruptcyResetFraction) {
-						this.currProcess = 0;
+						// 1st stop everything -- just in case
+						clearInterval(this.currOuterProcessHandle);
 						clearInterval(this.currProcessHandle);
+						// then start over (:
 						game.restartGame();
-						this.autoAutoAutocrat(); // super-safely clear the outer-loop too, for fresh businessesss (:
+						this.currProcess = 0;
+						this.autoAutoAutocrat();
 					}
 					break;
 				default:

--- a/AutocratV3.js
+++ b/AutocratV3.js
@@ -413,7 +413,7 @@ class IdleClassAutocrat {
 		
 		// Function to lazily kick off autocratManageLoopMillis outer loop
 		this.autoAutoAutocrat = function() {
-			if(this.currOuterProcessHandle !== 0) { clearInterval(this.currOuterProcessHandle); }
+			clearInterval(this.currOuterProcessHandle);
 			this.currOuterProcessHandle = setInterval(this.autoAutocrat.bind(this), this.autocratManageLoopMillis);
 		};
 	}


### PR DESCRIPTION
at one game, after already declaring bankruptcy, it ended up with locked r&d and 1 patent in it. only explanation to me is the small period, when you "wait" for case zero to hit in new game, while somewhat "older" task might still be running. i strongly believe it was a edgy thing to happen, but restarting the autocrat along the game sound super save though, right